### PR TITLE
Fix pylint/Python3 compatibility issues

### DIFF
--- a/bin/gpylinter.py
+++ b/bin/gpylinter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 Command-line script to automatically run lint.
 

--- a/lint/linters/pylinter.py
+++ b/lint/linters/pylinter.py
@@ -92,18 +92,10 @@ def pylint_raw(options):
     :param options:
     :return:
     """
-    if version_info[0] < 3:
-        with open(os.devnull, 'w') as devnull:
-            try:
-                command = ['pylint']
-                command.extend(options)
-                data = subprocess.check_output(command, stderr=devnull)
-            except subprocess.CalledProcessError as exception:
-                data = exception.output
+    command = ['pylint']
+    command.extend(options)
 
-    else:
-        command = ['pylint']
-        command.extend(options)
-        data = subprocess.getoutput(' '.join(command))
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    outs, __ = proc.communicate()
 
-    return data
+    return outs.decode()

--- a/lint/linters/pylinter.py
+++ b/lint/linters/pylinter.py
@@ -51,8 +51,8 @@ class Pylinter(Linter):
                 #Don't run on non-python files.
                 continue
             with cd_ctx(path):
-                short_data = pylint_raw([fname, "--reports=n", "-f", "text", '--confidence=HIGH'])
-                full_data = pylint_raw([fname, "--reports=y", "-f", "text", '--confidence=HIGH'])
+                short_data = pylint_raw([fname, "--reports=n", "-f", "text"])
+                full_data = pylint_raw([fname, "--reports=y", "-f", "text"])
 
             score_regex = re.search(r"Your code has been rated at (-?\d+\.\d+)", full_data)
             if score_regex:

--- a/lint/linters/pylinter.py
+++ b/lint/linters/pylinter.py
@@ -21,6 +21,7 @@ import re
 import os
 from lint.utils.general import cd_ctx
 from lint.linters.base_linter import Linter
+from sys import version_info
 
 
 class Pylinter(Linter):
@@ -50,8 +51,8 @@ class Pylinter(Linter):
                 #Don't run on non-python files.
                 continue
             with cd_ctx(path):
-                short_data = pylint_raw([fname, "--report=n", "-f", "text", '--confidence=HIGH'])
-                full_data = pylint_raw([fname, "--report=y", "-f", "text", '--confidence=HIGH'])
+                short_data = pylint_raw([fname, "--reports=n", "-f", "text", '--confidence=HIGH'])
+                full_data = pylint_raw([fname, "--reports=y", "-f", "text", '--confidence=HIGH'])
 
             score_regex = re.search(r"Your code has been rated at (-?\d+\.\d+)", full_data)
             if score_regex:
@@ -91,11 +92,18 @@ def pylint_raw(options):
     :param options:
     :return:
     """
-    with open(os.devnull, 'w') as devnull:
-        try:
-            command = ['pylint']
-            command.extend(options)
-            data = subprocess.check_output(command, stderr=devnull)
-        except subprocess.CalledProcessError as exception:
-            data = exception.output
+    if version_info[0] < 3:
+        with open(os.devnull, 'w') as devnull:
+            try:
+                command = ['pylint']
+                command.extend(options)
+                data = subprocess.check_output(command, stderr=devnull)
+            except subprocess.CalledProcessError as exception:
+                data = exception.output
+
+    else:
+        command = ['pylint']
+        command.extend(options)
+        data = subprocess.getoutput(' '.join(command))
+
     return data


### PR DESCRIPTION
There have been two incompatibilities with recent versions of pylint.
* command line parameter "report" has been renamed to "reports".
* subprocess.check_output failed because pylint exits with codes >0 which threw an exception in the code that deals with the pylint subprocess in Python3. Refactored the subprocess to use Popen/communicate to facilitate Python2.7 and 3.